### PR TITLE
[Org Update] Update .NET to net8.0,net9.0,net10.0

### DIFF
--- a/Source/Directory.Packages.props
+++ b/Source/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-	  <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-	  <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyVersion>0.1.7</AssemblyVersion>
@@ -13,20 +13,21 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageProjectUrl>https://github.com/Zonit</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Zonit/Zonit.Extensions.Organizations</RepositoryUrl>
-
-	  <!-- Debugging symbol settings -->
-	  <IncludeSymbols>true</IncludeSymbols>
-	  <IncludeSource>true</IncludeSource>
-	  <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <!-- Debugging symbol settings -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <IncludeSource>true</IncludeSource>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-		<PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-		<PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-		<PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
-		<PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-	</ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.11" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+  </ItemGroup>
 </Project>

--- a/Source/Zonit.Extensions.Organizations.Abstractions/Zonit.Extensions.Organizations.Abstractions.csproj
+++ b/Source/Zonit.Extensions.Organizations.Abstractions/Zonit.Extensions.Organizations.Abstractions.csproj
@@ -1,1 +1,1 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" />
+<Project Sdk="Microsoft.NET.Sdk" />

--- a/Source/Zonit.Extensions.Organizations/Zonit.Extensions.Organizations.csproj
+++ b/Source/Zonit.Extensions.Organizations/Zonit.Extensions.Organizations.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>

--- a/Tools/Update-DotNet.ps1
+++ b/Tools/Update-DotNet.ps1
@@ -1,0 +1,358 @@
+﻿<#
+.SYNOPSIS
+Updates .NET target frameworks and manages NuGet packages with Central Package Management.
+
+.DESCRIPTION
+This script:
+- Updates TargetFrameworks in all .csproj files
+- Removes Version attributes from PackageReference (enables central management)
+- Updates Directory.Packages.props with conditional ItemGroups per framework
+- Finds best compatible package versions for each framework
+- Supports prerelease packages for .NET 10+
+
+.PARAMETER TargetFrameworks
+List of target frameworks to support (e.g., "net8.0", "net9.0", "net10.0")
+
+.EXAMPLE
+.\Update-DotNet.ps1 net8.0 net9.0 net10.0
+
+.EXAMPLE
+.\Update-DotNet.ps1 -TargetFrameworks net8.0,net9.0,net10.0
+
+.NOTES
+Created for Zonit organization-wide .NET updates
+#>
+
+param(
+    [Parameter(Mandatory=$false, ValueFromRemainingArguments=$true)]
+    [string[]]$TargetFrameworks = @("net8.0", "net9.0", "net10.0")
+)
+
+$ErrorActionPreference = "Stop"
+
+if ($TargetFrameworks.Count -eq 0) {
+    Write-Error "Must provide at least one .NET version (e.g., .\Update-DotNet.ps1 net8.0 net9.0)"
+    exit 1
+}
+
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host ".NET Project Update" -ForegroundColor Cyan
+Write-Host "Target Frameworks: $($TargetFrameworks -join ', ')" -ForegroundColor Cyan
+Write-Host "========================================" -ForegroundColor Cyan
+
+# ============================================================================
+# FUNCTION: Get best package version for target framework
+# ============================================================================
+function Get-BestPackageVersion {
+    param(
+        [string]$PackageId,
+        [string]$TargetFramework,
+        [bool]$AllowPrerelease
+    )
+    
+    try {
+        $url = "https://api.nuget.org/v3-flatcontainer/$($PackageId.ToLower())/index.json"
+        $response = Invoke-RestMethod $url -TimeoutSec 15
+        $versions = $response.versions
+        
+        if ($TargetFramework -match 'net(\d+)') {
+            $targetMajor = [int]$matches[1]
+        } else {
+            Write-Warning "Cannot extract major version from $TargetFramework"
+            return $null
+        }
+        
+        $allVersions = $versions | ForEach-Object {
+            try {
+                $v = [version]($_ -replace '-.*', '')
+                [PSCustomObject]@{
+                    OriginalString = $_
+                    Version = $v
+                    IsPrerelease = $_ -match '-'
+                }
+            } catch { $null }
+        } | Where-Object { $_ -ne $null }
+        
+        # Strategy (priority order):
+        # 1. Latest stable with exact major version
+        # 2. Latest stable with lower major version
+        # 3. Latest prerelease with exact major (if AllowPrerelease)
+        
+        $best = $allVersions | Where-Object { 
+            -not $_.IsPrerelease -and $_.Version.Major -eq $targetMajor 
+        } | Sort-Object -Property @{Expression={$_.Version}; Descending=$true} | Select-Object -First 1
+        
+        if (-not $best) {
+            $best = $allVersions | Where-Object { 
+                -not $_.IsPrerelease -and $_.Version.Major -lt $targetMajor 
+            } | Sort-Object -Property @{Expression={$_.Version}; Descending=$true} | Select-Object -First 1
+        }
+        
+        if (-not $best -and $AllowPrerelease) {
+            $best = $allVersions | Where-Object { 
+                $_.Version.Major -eq $targetMajor 
+            } | Sort-Object -Property @{Expression={$_.Version}; Descending=$true} | Select-Object -First 1
+        }
+        
+        return $best.OriginalString
+    } catch {
+        Write-Warning "Error getting version for ${PackageId}: $_"
+        return $null
+    }
+}
+
+# ============================================================================
+# STEP 1: Update TargetFrameworks in .csproj
+# ============================================================================
+Write-Host "`n[1/4] Updating TargetFrameworks in .csproj files..." -ForegroundColor Yellow
+
+# Use singular or plural based on count
+$targetFrameworksString = $TargetFrameworks -join ';'
+$elementName = if ($TargetFrameworks.Count -eq 1) { "TargetFramework" } else { "TargetFrameworks" }
+
+$csprojs = Get-ChildItem -Recurse -Filter "*.csproj" | Where-Object { 
+    $_.FullName -notmatch '\\obj\\' -and $_.FullName -notmatch '\\bin\\' 
+}
+
+foreach ($proj in $csprojs) {
+    try {
+        [xml]$xml = Get-Content $proj.FullName
+        $propertyGroups = @($xml.Project.PropertyGroup)
+        if ($propertyGroups.Count -eq 0) {
+            $pg = $xml.CreateElement("PropertyGroup")
+            $xml.Project.AppendChild($pg) | Out-Null
+            $propertyGroups = @($pg)
+        }
+        
+        $pg = $propertyGroups[0]
+        
+        # Remove both singular and plural variants
+        @($pg.SelectNodes("TargetFramework")) | ForEach-Object { $pg.RemoveChild($_) | Out-Null }
+        @($pg.SelectNodes("TargetFrameworks")) | ForEach-Object { $pg.RemoveChild($_) | Out-Null }
+        
+        # Add correct element name
+        $tfNode = $xml.CreateElement($elementName)
+        $tfNode.InnerText = $targetFrameworksString
+        $pg.AppendChild($tfNode) | Out-Null
+        
+        $xml.Save($proj.FullName)
+        Write-Host "  ✓ $($proj.Name): Set to $targetFrameworksString" -ForegroundColor Green
+    } catch {
+        Write-Warning "  ✗ Failed to update $($proj.Name): $_"
+    }
+}
+
+# ============================================================================
+# STEP 2: Remove Version from PackageReference
+# ============================================================================
+Write-Host "`n[2/4] Removing Version attributes from PackageReference..." -ForegroundColor Yellow
+
+foreach ($proj in $csprojs) {
+    try {
+        $content = Get-Content $proj.FullName -Raw
+        $content = $content -replace '(<PackageReference\s+Include="[^"]+")(\s+Version="[^"]+")', '$1'
+        $content | Set-Content $proj.FullName -NoNewline
+        Write-Host "  ✓ $($proj.Name)" -ForegroundColor Gray
+    } catch {
+        Write-Warning "  ✗ Failed to process $($proj.Name): $_"
+    }
+}
+
+# ============================================================================
+# STEP 3: Collect all packages
+# ============================================================================
+Write-Host "`n[3/4] Collecting package references..." -ForegroundColor Yellow
+
+$allPackages = @{}
+foreach ($proj in $csprojs) {
+    try {
+        [xml]$xml = Get-Content $proj.FullName
+        $itemGroups = @($xml.Project.ItemGroup)
+        
+        foreach ($ig in $itemGroups) {
+            if ($ig) {
+                $packageRefs = @($ig.PackageReference)
+                foreach ($pkg in $packageRefs) {
+                    if ($pkg -and $pkg.Include) { 
+                        $allPackages[$pkg.Include] = $true 
+                    }
+                }
+            }
+        }
+    } catch {
+        Write-Warning "  ✗ Failed to read packages from $($proj.Name): $_"
+    }
+}
+
+$packageList = $allPackages.Keys | Sort-Object
+Write-Host "  Found $($packageList.Count) unique packages" -ForegroundColor Cyan
+
+# ============================================================================
+# STEP 4: Update Directory.Packages.props
+# ============================================================================
+Write-Host "`n[4/4] Updating Directory.Packages.props..." -ForegroundColor Yellow
+
+$propsFile = Get-ChildItem -Filter "Directory.Packages.props" -Recurse | Select-Object -First 1
+if (-not $propsFile) {
+    $propsPath = "Directory.Packages.props"
+    @"
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>
+"@ | Set-Content $propsPath
+    $propsFile = Get-Item $propsPath
+    Write-Host "  Created new Directory.Packages.props" -ForegroundColor Green
+}
+
+# Track package version changes for report
+$packageChanges = @()
+
+try {
+    [xml]$xml = Get-Content $propsFile.FullName
+    
+    # Collect OLD versions before removing
+    $oldVersions = @{}
+    $existingItemGroups = @($xml.Project.ItemGroup | Where-Object { $_.Condition -match "TargetFramework" })
+    foreach ($ig in $existingItemGroups) {
+        $condition = $ig.Condition
+        if ($condition -match "'.*?' == '(net\d+\.\d+)'") {
+            $framework = $matches[1]
+            foreach ($pv in $ig.PackageVersion) {
+                if ($pv.Include -and $pv.Version) {
+                    $key = "$($pv.Include)|$framework"
+                    $oldVersions[$key] = $pv.Version
+                }
+            }
+        }
+    }
+    
+    # Remove existing conditional ItemGroups
+    foreach ($ig in $existingItemGroups) {
+        $xml.Project.RemoveChild($ig) | Out-Null
+    }
+    
+    foreach ($tf in $TargetFrameworks) {
+        $allowPrerelease = $tf -match 'net1[0-9]'  # Allow prerelease for net10+
+        
+        Write-Host "  Processing $tf..." -ForegroundColor Cyan
+        
+        $itemGroup = $xml.CreateElement("ItemGroup")
+        $itemGroup.SetAttribute("Condition", "'`$(TargetFramework)' == '$tf'")
+        
+        foreach ($packageId in $packageList) {
+            $version = Get-BestPackageVersion -PackageId $packageId -TargetFramework $tf -AllowPrerelease $allowPrerelease
+            
+            if ($version) {
+                $pkgVersion = $xml.CreateElement("PackageVersion")
+                $pkgVersion.SetAttribute("Include", $packageId)
+                $pkgVersion.SetAttribute("Version", $version)
+                $itemGroup.AppendChild($pkgVersion) | Out-Null
+                
+                # Track changes
+                $key = "$packageId|$tf"
+                $oldVersion = $oldVersions[$key]
+                if ($oldVersion -and $oldVersion -ne $version) {
+                    $packageChanges += [PSCustomObject]@{
+                        Package = $packageId
+                        Framework = $tf
+                        OldVersion = $oldVersion
+                        NewVersion = $version
+                    }
+                }
+                
+                $prereleaseLabel = if ($version -match '-') { " (prerelease)" } else { "" }
+                $changeLabel = if ($oldVersion -and $oldVersion -ne $version) { " (was $oldVersion)" } else { "" }
+                Write-Host "    - $packageId → $version$prereleaseLabel$changeLabel" -ForegroundColor Gray
+            } else {
+                Write-Warning "    ✗ Could not find version for $packageId"
+            }
+            
+            # Rate limiting to respect NuGet API
+            Start-Sleep -Milliseconds 100
+        }
+        
+        $xml.Project.AppendChild($itemGroup) | Out-Null
+    }
+    
+    $xml.Save($propsFile.FullName)
+    Write-Host "  ✓ Saved Directory.Packages.props" -ForegroundColor Green
+    
+} catch {
+    Write-Error "Failed to update Directory.Packages.props: $_"
+    exit 1
+}
+
+# ============================================================================
+# SUMMARY
+# ============================================================================
+Write-Host "`n========================================" -ForegroundColor Green
+Write-Host "✓ Update Complete!" -ForegroundColor Green
+Write-Host "========================================" -ForegroundColor Green
+
+# Generate detailed change summary
+$changeSummary = @()
+if ($packageChanges.Count -gt 0) {
+    Write-Host "`nPackage Version Changes:" -ForegroundColor Cyan
+    
+    # Group by package for cleaner display
+    $grouped = $packageChanges | Group-Object Package
+    foreach ($group in $grouped) {
+        $changes = $group.Group | Sort-Object Framework
+        $pkg = $group.Name
+        
+        # If all frameworks have same change, show compact format
+        if (($changes | Select-Object -ExpandProperty OldVersion -Unique).Count -eq 1 -and 
+            ($changes | Select-Object -ExpandProperty NewVersion -Unique).Count -eq 1) {
+            $old = $changes[0].OldVersion
+            $new = $changes[0].NewVersion
+            Write-Host "  $pkg`: $old → $new" -ForegroundColor White
+            $changeSummary += "$pkg`: $old → $new"
+        } else {
+            # Different versions per framework
+            Write-Host "  $pkg`:" -ForegroundColor White
+            foreach ($change in $changes) {
+                Write-Host "    [$($change.Framework)] $($change.OldVersion) → $($change.NewVersion)" -ForegroundColor Gray
+                $changeSummary += "$pkg [$($change.Framework)]: $($change.OldVersion) → $($change.NewVersion)"
+            }
+        }
+    }
+} else {
+    Write-Host "`nNo package version changes detected" -ForegroundColor Yellow
+    $changeSummary += "No package version changes - this might be a new setup or no updates available"
+}
+
+# Generate report for PR automation
+$report = @{
+    Timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+    TargetFrameworks = $TargetFrameworks
+    ProjectsFound = $csprojs.Count
+    PackagesFound = $packageList.Count
+    PackageChanges = $packageChanges
+    ChangeSummary = $changeSummary
+    Summary = @{
+        ProjectsUpdated = $csprojs.Count
+        PackagesConfigured = $packageList.Count
+        PackagesChanged = $packageChanges.Count
+        FrameworksSet = $targetFrameworksString
+        DirectoryPackagesPropsUpdated = $propsFile -ne $null
+    }
+}
+
+$reportPath = "dotnet-update-report.json"
+$report | ConvertTo-Json -Depth 10 | Set-Content $reportPath -Encoding UTF8
+Write-Host "`nReport saved to: $reportPath" -ForegroundColor Gray
+
+Write-Host "`nSummary:" -ForegroundColor Cyan
+Write-Host "  Projects updated: $($csprojs.Count)" -ForegroundColor White
+Write-Host "  Target frameworks: $targetFrameworksString" -ForegroundColor White
+Write-Host "  Packages configured: $($packageList.Count)" -ForegroundColor White
+Write-Host "  Package versions changed: $($packageChanges.Count)" -ForegroundColor White
+
+Write-Host "`nNext steps:" -ForegroundColor Cyan
+Write-Host "  1. Run: dotnet restore" -ForegroundColor White
+Write-Host "  2. Run: dotnet build" -ForegroundColor White
+Write-Host "  3. Test and verify" -ForegroundColor White
+Write-Host ""

--- a/dotnet-update-report.json
+++ b/dotnet-update-report.json
@@ -1,0 +1,35 @@
+{
+  "TargetFrameworks": [
+    "net8.0",
+    "net9.0",
+    "net10.0"
+  ],
+  "ProjectsFound": 2,
+  "ChangeSummary": [
+    "Microsoft.Extensions.DependencyInjection.Abstractions: 9.0.1 → 9.0.11",
+    "Microsoft.Extensions.Hosting: 9.0.1 → 9.0.11"
+  ],
+  "PackageChanges": [
+    {
+      "Package": "Microsoft.Extensions.DependencyInjection.Abstractions",
+      "Framework": "net9.0",
+      "OldVersion": "9.0.1",
+      "NewVersion": "9.0.11"
+    },
+    {
+      "Package": "Microsoft.Extensions.Hosting",
+      "Framework": "net9.0",
+      "OldVersion": "9.0.1",
+      "NewVersion": "9.0.11"
+    }
+  ],
+  "PackagesFound": 2,
+  "Summary": {
+    "PackagesConfigured": 2,
+    "ProjectsUpdated": 2,
+    "PackagesChanged": 2,
+    "FrameworksSet": "net8.0;net9.0;net10.0",
+    "DirectoryPackagesPropsUpdated": true
+  },
+  "Timestamp": "2025-11-15 19:16:17"
+}


### PR DESCRIPTION
### Organization-Wide .NET Update

This PR was created as part of an organization-wide .NET update.

**Target Frameworks:** `net8.0,net9.0,net10.0`

**Tracking Issue:** https://github.com/Zonit/.github/issues/2

---

#### What Changed:
- **Projects Updated:** 2
- **Packages Configured:** 2
- **Package Versions Changed:** 2
- **Target Frameworks:** `net8.0;net9.0;net10.0`
- **Central Package Management:** Enabled

**The following NuGet packages were updated:**

```
```

---

**Next Steps:**
1. Review changes
2. Run `dotnet restore`
3. Run `dotnet build`
4. Run tests
5. Merge when ready

**Part of:** Organization-wide .NET update
**Tracking:** https://github.com/Zonit/.github/issues/2
